### PR TITLE
Skip resizing image if downsampleFactor is one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ export class AppiumOcrPlugin extends BasePlugin {
             sharpImage = sharpImage.negate();
         }
 
-        if (downsampleFactor && downsampleFactor != 1) {
+        if (downsampleFactor && downsampleFactor !== 1) {
             this.logger.info(`Using downsample factor of ${downsampleFactor}`)
             const { width: curWidth, height: curHeight } = await sharpImage.metadata();
             if (!curWidth || !curHeight) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,7 +186,7 @@ export class AppiumOcrPlugin extends BasePlugin {
             sharpImage = sharpImage.negate();
         }
 
-        if (downsampleFactor) {
+        if (downsampleFactor && downsampleFactor != 1) {
             this.logger.info(`Using downsample factor of ${downsampleFactor}`)
             const { width: curWidth, height: curHeight } = await sharpImage.metadata();
             if (!curWidth || !curHeight) {


### PR DESCRIPTION
I'm using Appium-ocr-plugin with Appium server running on Docker.
Most of the time, iOS tests fail with the following error: 

```
2024-10-08 19:13:13.893 [944069a6][Plugin [ocr]] Using 3.12 as the screenshot-to-screen size ratio
2024-10-08 19:13:13.894 [944069a6][Plugin [ocr]] Using downsample factor of 3.12
2024-10-08 19:13:13.896 munmap_chunk(): invalid pointer
2024-10-08 19:13:14.409 Aborted (core dumped)
```

As a workaround, I want to set the downsample factor to 1 (via driver settings) to prevent resizing the screenshot image. 
However, even when I set it to 1, the code still executes the section that leads to this error.